### PR TITLE
Updates to make plugin not send pages for warnings or errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@ Cabot Pagerduty Plugin
 This is a pagerduty alert plugin for Cabot.
 
 ### Usage
-This plugin is used for alerting to Pagerduty from Cabot. The implementation is a hack, because of the current pagerduty design. The alerting parameters are configured on a per-user basis and not per service. (hipchat, email, phone-no etc.)
+This plugin is used for alerting to Pagerduty from Cabot. The implementation is
+a hack, because of the current pagerduty design. The alerting parameters are
+configured on a per-user basis and not per service. (hipchat, email, phone-no etc.)
 
-Once you install this plugin,
-* add a user dedicated to pagerduty
-* configure this user as "fallback duty officer"
-* configure the service key in this user's profile
+###Once you install this plugin:
+####In PagerDuty:
+* Create a V1 API Token. This will be needed for the Cabot configuration
+value ```PAGERDUTY_API_TOKEN```
+* Create a new Service. Add a Generic API integration. An Integration or
+Service Key will be generated to be used for creating the specific user
+to link to the PagerDuty escalation policy. Which users are alerted by
+Pagerduty will be configured as part of this policy.
+
+####In Cabot:
+* Add a user dedicated to a specific Pagerduty Escalation Policy
+* Configure this user as "fallback duty officer"
+* Configure the service key in this user's profile

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -28,6 +28,9 @@ class PagerdutyAlert(AlertPlugin):
     def send_alert(self, service, users, duty_officers):
         """Implement your send_alert functionality here."""
 
+        if not self._service_alertable(service):
+            return
+
         subdomain = os.environ.get('PAGERDUTY_SUBDOMAIN')
         api_token = os.environ.get('PAGERDUTY_API_TOKEN')
 
@@ -60,6 +63,19 @@ class PagerdutyAlert(AlertPlugin):
                                             incident_key=incident_key)
             except Exception, exp:
                 logger.exception('Error invoking pagerduty: %s' % str(exp))
+
+    def _service_alertable(self, service):
+
+        alertable_status = [service.ERROR_STATUS, service.CRITICAL_STATUS]
+
+        if service.overall_status in alertable_status:
+            return True
+
+        if service.overall_status == service.PASSING_STATUS and \
+            service.old_overall_status in alertable_status:
+            return True
+
+        return False
 
 
 class PagerdutyAlertUserData(AlertPluginUserData):


### PR DESCRIPTION
Cabot philosophy indicates pages should be sent for a critical alerts. This plugin alerts for all service status levels.