### PR TITLE
Make plugin alert status aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 nosetests.xml
 coverage.xml
 .venv
+venv/*
 *.swp
 *.swo
 *~
@@ -10,5 +11,7 @@ coverage.xml
 
 .eggs/
 _build/
+build/*
+dist/*
 *.pyc
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -3,9 +3,27 @@ Cabot Pagerduty Plugin
 This is a pagerduty alert plugin for Cabot.
 
 ### Usage
-This plugin is used for alerting to Pagerduty from Cabot. The implementation is a hack, because of the current pagerduty design. The alerting parameters are configured on a per-user basis and not per service. (hipchat, email, phone-no etc.)
+This plugin is used for alerting to Pagerduty from Cabot. The implementation is
+a hack, because of the current pagerduty design. The alerting parameters are
+configured on a per-user basis and not per service. (hipchat, email, phone-no etc.)
 
-Once you install this plugin,
-* add a user dedicated to pagerduty
-* configure this user as "fallback duty officer"
-* configure the service key in this user's profile
+###Once you install this plugin:
+####In PagerDuty:
+* Create a V1 API Token. This will be needed for the Cabot configuration
+value ```PAGERDUTY_API_TOKEN```
+* Create a new Service. Add a Generic API integration. An Integration or
+Service Key will be generated to be used for creating the specific user
+to link to the PagerDuty escalation policy. Which users are alerted by
+Pagerduty will be configured as part of this policy.
+
+####In Cabot Configuration:
+* Set ```PAGERDUTY_API_TOKEN``` to value configured in Pagerduty
+* Set ```PAGERDUTY_SUBDOMAIN``` for Pagerduty API endpoint
+* If alerts should be sent to Pagerduty for a service status check other than
+critical, configure a comma-separated list for ```PAGERDUTY_ALERT_STATUS```
+e.g. 'ERROR,CRITICAL'
+
+####In Cabot:
+* Add a user dedicated to a specific Pagerduty Escalation Policy
+* Configure this user as "fallback duty officer"
+* Configure the service key in this user's profile

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-
 from setuptools import setup
 
-__VERSION__ = '1.0.1'
+__VERSION__ = '1.0.2'
 
 setup(name='cabot-alert-pagerduty',
       version=__VERSION__,
@@ -16,5 +15,8 @@ setup(name='cabot-alert-pagerduty',
       download_url='https://github.com/Affirm/cabot-alert-pagerduty/tarball/%s' % __VERSION__,
       install_requires=[
         'pygerduty==0.14',
+      ],
+      tests_require=[
+        'cabot',
       ],
      )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import

--- a/tests/bootstrap_tests.py
+++ b/tests/bootstrap_tests.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+settings.configure()
+settings.JENKINS_USER = 'Test'
+settings.JENKINS_PASS = 'Test'
+settings.GRAPHITE_API = 'Test'
+settings.GRAPHITE_USER = 'Test'
+settings.GRAPHITE_PASS = 'Test'
+settings.GRAPHITE_FROM = 'Test'

--- a/tests/unit/test_service_status_check.py
+++ b/tests/unit/test_service_status_check.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+import tests.bootstrap_tests
+
+from cabot.cabotapp.models import Service
+from cabot_alert_pagerduty.models import PagerdutyAlert
+# from cabot_alert_pagerduty.models import _service_alertable
+from cabot_alert_pagerduty.models import _gather_alertable_status
+
+class TestServiceStatusChecks(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_critical_alertable(self):
+        """ A service with a critical status is alertable """
+        service = Service()
+
+        plugin = PagerdutyAlert()
+
+        service.overall_status = service.CRITICAL_STATUS
+        self.assertTrue(plugin._service_alertable(service))
+
+    def test_non_critical_alertable(self):
+        """ A non-critical service status does not alert """
+        service = Service()
+
+        plugin = PagerdutyAlert()
+
+        service.overall_status = service.WARNING_STATUS
+        self.assertFalse(plugin._service_alertable(service))
+
+        service.overall_status = service.ERROR_STATUS
+        self.assertFalse(plugin._service_alertable(service))
+
+    def test_default_critical_status(self):
+
+        os.environ.pop('PAGERDUTY_ALERT_STATUS', None)
+
+        default_alert_status = ['CRITICAL']
+        self.assertEqual(default_alert_status, _gather_alertable_status())
+
+    def test_default_status_in_plugin(self):
+
+        os.environ.pop('PAGERDUTY_ALERT_STATUS', None)
+
+        default_alert_status = ['CRITICAL']
+        plugin = PagerdutyAlert()
+
+        self.assertEqual(default_alert_status, plugin.alert_status_list)
+
+    def test_configured_status_in_plugin(self):
+
+        os.environ['PAGERDUTY_ALERT_STATUS'] = 'CRITICAL,WARNING'
+
+        custom_alert_status = ['CRITICAL', 'WARNING']
+        plugin = PagerdutyAlert()
+
+        self.assertEqual(custom_alert_status, plugin.alert_status_list)
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(TestServiceStatusChecks)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
To match the Cabot philosophy of phone calls only alerting in the most critical of alerts, this PR adds a configuration item for setting what alert status will trigger a call to Pagerduty. By default the plugin will now only alert on critical status checks. Additional service alert status setting can be set via a Cabot setting.