### PR TITLE
LD-771: Include check key in incident key so different failed checks aren't under the same PD incident

### DIFF
--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -44,9 +44,6 @@ class PagerdutyAlert(AlertPlugin):
 
         client = pygerduty.PagerDuty(subdomain, api_token)
 
-        description = 'Service: %s is %s' % (service.name,
-                                             service.overall_status)
-
         users = service.users_to_notify.all()
 
         service_info = []
@@ -57,21 +54,21 @@ class PagerdutyAlert(AlertPlugin):
         failed_checks = [check for check in service.all_failing_checks()]
         
         for service_key, separate_alert_per_check in service_info:
+            description = 'Service: %s is %s' % (service.name, service.overall_status)
             incident_key = '%s/%d' % (service.name.lower().replace(' ', '-'), service.pk)
             
             if separate_alert_per_check:
                 for failed_check in failed_checks:
-                    alert_description = '%s failed check [%s]' % (description, failed_check.name)
-                    alert_incident_key = '%s/%d' % (incident_key, failed_check.pk)
+                    check_description = '%s failed check [%s]' % (description, failed_check.name)
+                    check_incident_key = '%s/%d' % (incident_key, failed_check.pk)
                     
-                    _process_alert(service, client, service_key, alert_incident_key, alert_description)
+                    _process_alert(service, client, service_key, check_incident_key, check_description)
                     
             else:
                 if len(failed_checks) > 0:
                     description += ' failed checks [%s]' % ','.join(check.name for check in failed_checks)
                 
                 _process_alert(service, client, service_key, incident_key, description)
-        
 
     def _process_alert(self, service, client, service_key, incident_key, description):
         try:

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -68,7 +68,7 @@ class PagerdutyAlert(AlertPlugin):
                                                 incident_key)
                     else:
                         client.trigger_incident(service_key,
-                                                alert_description,
+                                                description,
                                                 incident_key=incident_key)
                 except Exception, exp:
                     logger.exception('Error invoking pagerduty: %s' % str(exp))

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -49,15 +49,15 @@ class PagerdutyAlert(AlertPlugin):
         service_info = []
         for userdata in PagerdutyAlertUserData.objects.filter(user__user__in=users):
             if userdata.service_key:
-                service_info.append((str(userdata.service_key), user_data.separate_alert_per_check))
+                service_info.append((str(userdata.service_key), user_data.separate_alerts_per_check))
 
         failed_checks = [check for check in service.all_failing_checks()]
         
-        for service_key, separate_alert_per_check in service_info:
+        for service_key, separate_alerts_per_check in service_info:
             description = 'Service: %s is %s' % (service.name, service.overall_status)
             incident_key = '%s/%d' % (service.name.lower().replace(' ', '-'), service.pk)
             
-            if separate_alert_per_check:
+            if separate_alerts_per_check:
                 for failed_check in failed_checks:
                     check_description = '%s failed check [%s]' % (description, failed_check.name)
                     check_incident_key = '%s/%d' % (incident_key, failed_check.pk)
@@ -104,4 +104,4 @@ def _gather_alertable_status():
 class PagerdutyAlertUserData(AlertPluginUserData):
     name = "Pagerduty Plugin"
     service_key = models.CharField(max_length=50, blank=True, null=True)
-    separate_alert_per_check = models.BooleanField(default=False)
+    separate_alerts_per_check = models.BooleanField(default=False)

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -48,14 +48,14 @@ class PagerdutyAlert(AlertPlugin):
                                              service.overall_status)
 
         users = service.users_to_notify.all()
-        
+
         service_keys = []
         for userdata in PagerdutyAlertUserData.objects.filter(user__user__in=users):
             if userdata.service_key:
                 service_keys.append(str(userdata.service_key))
-                
+
         failed_checks = [check for check in service.all_failing_checks()]
-        
+
         for failed_check in failed_checks:
             description = '%s failed check [%s]' % (description_prefix, failed_check.name)
             incident_key = '%s/%d/%d' % (service.name.lower().replace(' ', '-'),


### PR DESCRIPTION
Right now, several checks are grouped under a single alert/incident in PagerDuty because of how the incident key is formed. This is causing alerts of varying severity to be grouped together and increases the likelihood of the on-call engineer missing an issue.
Example: [alert](https://affirm.pagerduty.com/alerts/Q36LCCO6QILASB/log_entries/R5OM7USDPN1RYGMGZOCJDP3X1Q), [incident](https://affirm.pagerduty.com/incidents/Q3OXPD8H8T57ZV)